### PR TITLE
[docs] [backend] fix incorrect repository URL in Chinese README

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -47,9 +47,9 @@ Coze Loop 通过提供全生命周期的管理能力，帮助开发者更高效�
 1. 获取源码。执行以下命令，获取 Coze Loop 最新版本的源码。
    ```Bash
    # 克隆代码
-   git clone https://github.com/coze-dev/Coze Loop.git
+   git clone https://github.com/coze-dev/cozeloop.git
    # 进入Coze Loop目录下
-   cd Coze Loop
+   cd cozeloop
    ```
 2. 配置模型。进入目录 `conf/default/app/runtime/`，编辑文件 `model_config.yaml`，修改 api_key 和 model 字段。以火山方舟为例：
    * api_key：火山方舟 API Key，获取方式可参考[获取 API Key](Keyhttps://www.volcengine.com/docs/82379/1541594)。


### PR DESCRIPTION
#### What type of PR is this?

docs: Documentation only changes

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.

docs: 修复中文文档中的仓库URL和目录名称错误

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: Fixed incorrect repository URL and directory name in the Chinese README file. The git clone command contained spaces in the URL and the directory name didn't match the actual repository name, which would cause users to fail when following the installation instructions.

zh(optional): 修复了中文README文件中的仓库URL和目录名称错误。git clone命令中的URL包含空格，且目录名称与实际仓库名称不匹配，这会导致用户按照安装说明操作时失败。

#### (Optional) Which issue(s) this PR fixes:

N/A - This is a documentation fix identified during code review.
